### PR TITLE
Clean up

### DIFF
--- a/lib/ticking_away.rb
+++ b/lib/ticking_away.rb
@@ -1,6 +1,6 @@
 require 'ticking_away/chat_bot'
 require 'ticking_away/cinch/plugins/time_info'
 require 'ticking_away/world_time'
-require 'ticking_away/custom_errors'
+require 'ticking_away/errors'
 require 'ticking_away/json_file_storage'
 require 'ticking_away/bot'

--- a/lib/ticking_away/bot.rb
+++ b/lib/ticking_away/bot.rb
@@ -76,7 +76,7 @@ module TickingAway
     rescue TickingAway::Errors::UnrecognizedTimeZone => e
       puts e.message
       'unknown timezone'
-    rescue => e
+    rescue TickingAway::Errors::TimeTravelIsHard => e
       puts e.message
       EXCUSES.sample
     end

--- a/lib/ticking_away/cinch/plugins/time_info.rb
+++ b/lib/ticking_away/cinch/plugins/time_info.rb
@@ -42,8 +42,9 @@ module TickingAway
   class TimeInfo
     include ::Cinch::Plugin
 
-    match (/timeat */), method: :timeat
-    match (/timepopularity */), method: :timepopularity
+    # regex needs work
+    match %r{timeat [a-zA-Z0-9_\-/]+}, method: :timeat
+    match %r{timepopularity [a-zA-Z0-9_\-/]+}, method: :timepopularity
 
     listen_to :connect, method: :on_connect
 

--- a/lib/ticking_away/errors.rb
+++ b/lib/ticking_away/errors.rb
@@ -2,6 +2,7 @@ module TickingAway
   module Errors
     # Custom Errors
     class UnrecognizedTimeZone < StandardError; end
-    class ApiUrlNotFound < StandardError; end
+
+    class TimeTravelIsHard < StandardError; end
   end
 end

--- a/lib/ticking_away/json_file_storage.rb
+++ b/lib/ticking_away/json_file_storage.rb
@@ -24,18 +24,20 @@ module TickingAway
     end
 
     # Get the number of times !timeat was called for a
-    # tz_info or prefix. Partial prefix matches count towards
-    # the total.
-    # If we didn't want them to, it could check the
-    # next char in the key after the .start_with? match. If it's outside the
-    # length or a "/", then the prefix or tz_info matches exactly
+    # tz_info or prefix. Partial prefix matches do not count.
     def get_stat(stat_name)
       call_count = 0
       stats.each do |key, value|
-        call_count += value if key.start_with?(stat_name)
+        call_count += value if key.start_with?(stat_name) && full_match?(stat_name, key)
       end
 
       call_count
+    end
+
+    def full_match?(stat_name, key)
+      return true if key.length == stat_name.length || key[stat_name.length] == '/'
+
+      false
     end
 
     def save_stats

--- a/lib/ticking_away/world_time.rb
+++ b/lib/ticking_away/world_time.rb
@@ -14,22 +14,24 @@ module TickingAway
       def time_at(base_url, tz_info)
         request_url = "#{base_url}/timezone/#{tz_info}"
 
-        response = HTTParty.get(request_url)
+        response = call_api(request_url)
         handle_response(response, request_url)
       end
 
       def call_api(request_url)
         HTTParty.get(request_url)
       rescue => e
-        raise e.extend(TickingAway::Errors::TimeTravelIsHard)
+        raise TickingAway::Errors::TimeTravelIsHard, e.message
       end
 
       def handle_response(response, request_url)
         # Convert JSON response to Hash, handling an empty or nil body
-        parsed_response = response.body.nil? || response.body.empty? ? {} : JSON.parse(response.body)
+        parsed_response = parse_response(response.body)
 
         case response.code
         when 200
+          raise TickingAway::Errors::UnrecognizedTimeZone, 'Error: non-time response' unless parsed_response.is_a?(Hash)
+
           puts "Event: Retreived current time for #{parsed_response['timezone']}: #{parsed_response['datetime']}"
         when 404
           # Differentiate between an unknown location response and a random 404 by checking the response body
@@ -44,6 +46,12 @@ module TickingAway
 
         # Convert the time from a RFC3339 formatted string to a Time object
         Time.parse(parsed_response['datetime'])
+      end
+
+      def parse_response(body)
+        JSON.parse(body)
+      rescue => e
+        raise TickingAway::Errors::TimeTravelIsHard, e.message
       end
     end
   end

--- a/lib/ticking_away/world_time.rb
+++ b/lib/ticking_away/world_time.rb
@@ -16,9 +16,12 @@ module TickingAway
 
         response = HTTParty.get(request_url)
         handle_response(response, request_url)
+      end
+
+      def call_api(request_url)
+        HTTParty.get(request_url)
       rescue => e
-        puts "Could not connect to time server #{request_url}"
-        raise e
+        raise e.extend(TickingAway::Errors::TimeTravelIsHard)
       end
 
       def handle_response(response, request_url)
@@ -34,9 +37,9 @@ module TickingAway
             raise TickingAway::Errors::UnrecognizedTimeZone, "Error: Unrecognized Time Zone #{request_url}"
           end
 
-          raise TickingAway::Errors::ApiUrlNotFound, "Error: 404 response for #{request_url}"
+          raise TickingAway::Errors::TimeTravelIsHard, "Error: 404 response for #{request_url}"
         else
-          raise "Error: #{response.code} #{parsed_response}"
+          raise TickingAway::Errors::TimeTravelIsHard, "Error: #{response.code} #{parsed_response}"
         end
 
         # Convert the time from a RFC3339 formatted string to a Time object

--- a/test/ticking_away/json_file_storage_test.rb
+++ b/test/ticking_away/json_file_storage_test.rb
@@ -34,6 +34,19 @@ class TickingAway::JSONFileStorageTest < TickingAwayTest
     clear_file
   end
 
+  def test_get_stat_no_partial
+    stat_name = 'America/Los_Angeles'
+
+    @storage.increment_stat(stat_name)
+    @storage.increment_stat("#{stat_name}/Taco_Bell")
+    @storage.increment_stat("#{stat_name}/Pizza_Hut")
+
+    actual = @storage.get_stat('Ameri')
+    expected = 0
+    assert_equal(actual, expected)
+    clear_file
+  end
+
   def clear_file
     File.delete(@filename) if File.file?(@filename)
   end

--- a/test/ticking_away/world_time_test.rb
+++ b/test/ticking_away/world_time_test.rb
@@ -55,7 +55,7 @@ class TickingAway::WorldTimeTest < TickingAwayTest
     end
   end
 
-  def test_non_time_response
+  def test_array_response
     stub_request(:any, @request_url)
       .to_return(body: [1..5].to_json, status: 200)
 
@@ -63,5 +63,15 @@ class TickingAway::WorldTimeTest < TickingAwayTest
       TickingAway::WorldTime.time_at(@base_url, @tz_info)
     end
     assert_equal('Error: non-time response', exception.message)
+  end
+
+  def test_non_time_response
+    stub_request(:any, @request_url)
+      .to_return(body: '<html>asdfasdf</html>', status: 503)
+
+    exception = assert_raises TickingAway::Errors::TimeTravelIsHard do
+      TickingAway::WorldTime.time_at(@base_url, @tz_info)
+    end
+    assert_equal("809: unexpected token at '<html>asdfasdf</html>'", exception.message)
   end
 end

--- a/test/ticking_away/world_time_test.rb
+++ b/test/ticking_away/world_time_test.rb
@@ -50,7 +50,7 @@ class TickingAway::WorldTimeTest < TickingAwayTest
     stub_request(:any, @request_url)
       .to_return(body: nil, status: 500)
 
-    exception = assert_raises TickingAway::Errors::TimeTravelIsHard do
+    assert_raises TickingAway::Errors::TimeTravelIsHard do
       TickingAway::WorldTime.time_at(@base_url, @tz_info)
     end
   end

--- a/test/ticking_away/world_time_test.rb
+++ b/test/ticking_away/world_time_test.rb
@@ -53,6 +53,15 @@ class TickingAway::WorldTimeTest < TickingAwayTest
     exception = assert_raises TickingAway::Errors::TimeTravelIsHard do
       TickingAway::WorldTime.time_at(@base_url, @tz_info)
     end
-    assert_equal('Error: 500 {}', exception.message)
+  end
+
+  def test_non_time_response
+    stub_request(:any, @request_url)
+      .to_return(body: [1..5].to_json, status: 200)
+
+    exception = assert_raises TickingAway::Errors::UnrecognizedTimeZone do
+      TickingAway::WorldTime.time_at(@base_url, @tz_info)
+    end
+    assert_equal('Error: non-time response', exception.message)
   end
 end

--- a/test/ticking_away/world_time_test.rb
+++ b/test/ticking_away/world_time_test.rb
@@ -50,7 +50,7 @@ class TickingAway::WorldTimeTest < TickingAwayTest
     stub_request(:any, @request_url)
       .to_return(body: nil, status: 500)
 
-    exception = assert_raises RuntimeError do
+    exception = assert_raises TickingAway::Errors::TimeTravelIsHard do
       TickingAway::WorldTime.time_at(@base_url, @tz_info)
     end
     assert_equal('Error: 500 {}', exception.message)


### PR DESCRIPTION
This is cleaning up error handling for the time api class. Also making it so that partial matches do not count for !timepopularity and taking an ugly shot at regex